### PR TITLE
Made metaKey to behave like ctrlKey for Mac users

### DIFF
--- a/markitup/jquery.markitup.js
+++ b/markitup/jquery.markitup.js
@@ -502,7 +502,7 @@
 			function keyPressed(e) { 
 				shiftKey = e.shiftKey;
 				altKey = e.altKey;
-				ctrlKey = (!(e.altKey && e.ctrlKey)) ? e.ctrlKey : false;
+				ctrlKey = (!(e.altKey && e.ctrlKey)) ? e.ctrlKey || e.metaKey : false;
 
 				if (e.type === 'keydown') {
 					if (ctrlKey === true) {


### PR DESCRIPTION
Hello, I made metaKey behave like ctrlKey. It is usable for Mac OS X users, because Mac browsers triggers metaKey when Cmd key is pressed so users can use Mac-native shortcuts like Cmd+B for bold etc. I've tested metaKey behaviour in Opera, Safari, Chrome, Firefox and MSIE from 6 to 8 and it seems to me that this change has no negative side effects.
