### PR TITLE
togglePreview method, iframe preview height from textarea

### DIFF
--- a/markitup/jquery.markitup.js
+++ b/markitup/jquery.markitup.js
@@ -428,6 +428,7 @@
 						});
 					} else {
 						iFrame = $('<iframe class="markItUpPreviewFrame"></iframe>');
+						iFrame.height($(textarea).outerHeight());
 						if (options.previewPosition == 'after') {
 							iFrame.insertAfter(footer);
 						} else {


### PR DESCRIPTION
Hello, I've made two small changes which improves MakitUp! editor little bit in my opinion.

For first, I have added togglePreview method which can be used to create single toolbar button for enabling/disabling preview. I think that button with such behavior is typical feature of WYSIWYG/WYMIWYG editors and users awaits it.

For second, I have made MarkitUp! editor to set preview iframe height to the size of textarea with markup. It seems to me practical in cases when editor is used for editing many different contents on one site. The preview needs to be much taller for blog post body than for photo description for example. Of course, height can be set with CSS for each case, but isn't easier to have this happen automagically? :)

Consider, if theese changes can't be helpful for other MarkitUp! users. Thank you.
