### PR TITLE
Adding previewHandler to skip MIU preview rendering and handle it all "manually"

### DIFF
--- a/markitup/jquery.markitup.js
+++ b/markitup/jquery.markitup.js
@@ -32,6 +32,7 @@
 		options = {	id:						'',
 					nameSpace:				'',
 					root:					'',
+					previewHandler:			false,
 					previewInWindow:		'', // 'width=800, height=600, resizable=yes, scrollbars=yes'
 					previewAutoRefresh:		true,
 					previewPosition:		'after',
@@ -440,7 +441,9 @@
 
 			// open preview window
 			function preview() {
-				if (!previewWindow || previewWindow.closed) {
+				if (typeof options.previewHandler === 'function') {
+					previewWindow = true;
+				} else if (!previewWindow || previewWindow.closed) {
 					if (options.previewInWindow) {
 						previewWindow = window.open('', 'preview', options.previewInWindow);
 						$(window).unload(function() {
@@ -476,9 +479,11 @@
  				renderPreview();
 			}
 
-			function renderPreview() {		
+			function renderPreview() {
 				var phtml;
-				if (options.previewParser && typeof options.previewParser === 'function') {
+				if (options.previewHandler && typeof options.previewHandler === 'function') {
+					options.previewHandler( $$.val() );
+				} else if (options.previewParser && typeof options.previewParser === 'function') {
 					var data = options.previewParser( $$.val() );
 					writeInPreview( localize(data, 1) ); 
 				} else if (options.previewParserPath !== '') {


### PR DESCRIPTION
I'm trying to use client-side preview (Markdown in my case) and the trouble is that when I use the `previewParser` option, I don't really have a chance to style my preview (the template is not used, and nothing in the `iframe` can be styled due to XSS..at least I'm not aware it's possible).

The `previewHandler` option would simply be a custom function provided by the user to handle _everything_: parsing, preview element.. and skip the MIU logic entirely.

This allows for completely custom previews, for example, I can now put my preview in a div wherever and whenever I need it, and I don't have to depend on MIU positioning or styling etc. (not that there's anything wrong with that:))
