### PR TITLE
Fixed Ctrl+Enter to insert <p> tag

### DIFF
--- a/markitup/jquery.markitup.js
+++ b/markitup/jquery.markitup.js
@@ -534,7 +534,7 @@
 
 				if (e.type === 'keydown') {
 					if (ctrlKey === true) {
-						li = $('a[accesskey="'+String.fromCharCode(e.keyCode)+'"]', header).parent('li');
+						li = $('a[accesskey="'+((e.keyCode == 13) ? '\\n' : String.fromCharCode(e.keyCode))+'"]', header).parent('li');
 						if (li.length !== 0) {
 							ctrlKey = false;
 							setTimeout(function() {


### PR DESCRIPTION
Since the accesskey value was quoted in version 1.1.11, pressing Ctrl+Enter results in a syntax error due to the non-escaped line break in the middle of the string as shown currently in the latest stable release: http://markitup.jaysalvat.com/downloads/demo.php?id=releases/latest

This fix works by manually escaping the line break character, allowing the script to insert a `<p>` tag when Ctrl+Enter is pressed.
