### PR TITLE
Fix IE9 Quirks Mode Syntax Error with jQuery 1.8

### DIFF
--- a/markitup/jquery.markitup.js
+++ b/markitup/jquery.markitup.js
@@ -279,6 +279,7 @@
 
 			// define markup to insert
 			function markup(button) {
+				if (textarea.disabled) return false;
 				var len, j, n, i;
 				hash = clicked = button;
 				get();
@@ -385,7 +386,6 @@
 				
 			// add markup
 			function insert(block) {
-				if (textarea.disabled) return false;
 				if (document.selection) {
 					var newSelection = document.selection.createRange();
 					newSelection.text = block;
@@ -441,6 +441,7 @@
 
 			// open preview window
 			function preview() {
+				if (textarea.disabled) return false;
 				if (typeof options.previewHandler === 'function') {
 					previewWindow = true;
 				} else if (!previewWindow || previewWindow.closed) {


### PR DESCRIPTION
Removed a line which does nothing: `$('li:hover > ul', ul)` will always return an empty jQuery object due to context selector `ul` having no descendant elements when this selector runs.

It also solves a `Syntax error, unrecognized expression: unsupported pseudo: hover` when using jQuery 1.8 with IE9 in Quirks mode which doesn't support the pseudo-selector `:hover` used in the selector expression.
