### PR TITLE
add ability to render preview in div on same page

### DIFF
--- a/markitup/jquery.markitup.js
+++ b/markitup/jquery.markitup.js
@@ -526,7 +526,6 @@
 						sp = 0;
 					}	
 					previewWindow.document.open();
-					previewWindow.document.write(previewWindow.name);
 					previewWindow.document.write(data);
 					previewWindow.document.close();
 					previewWindow.document.documentElement.scrollTop = sp;


### PR DESCRIPTION
With this change, you can add an additional setting to your set to render your preview output in a div (or any html dom element) on the same page.

```
 previewInDiv:   'preview1', // send preview to div id "preview1"
```
