### PR TITLE
Fixed default (placeHolder) selection after using a tag having either openBlockWith or closeBlockWith property

### DIFF
--- a/markitup/jquery.markitup.js
+++ b/markitup/jquery.markitup.js
@@ -294,10 +294,12 @@
 				block = openBlockWith + block + closeBlockWith;
 
 				return {	block:block, 
+							openBlockWith:openBlockWith,
 							openWith:openWith, 
 							replaceWith:replaceWith, 
 							placeHolder:placeHolder,
-							closeWith:closeWith
+							closeWith:closeWith,
+							closeBlockWith:closeBlockWith
 					};
 			}
 
@@ -358,8 +360,8 @@
 				if ((selection === '' && string.replaceWith === '')) {
 					caretOffset += fixOperaBug(string.block);
 					
-					start = caretPosition + string.openWith.length;
-					len = string.block.length - string.openWith.length - string.closeWith.length;
+					start = caretPosition + string.openBlockWith.length + string.openWith.length;
+					len = string.block.length - string.openBlockWith.length - string.openWith.length - string.closeWith.length - string.closeBlockWith.length;
 
 					caretOffset = $$.val().substring(caretPosition,  $$.val().length).length;
 					caretOffset -= fixOperaBug($$.val().substring(0, caretPosition));


### PR DESCRIPTION
Hi,

thank you for this great library!

I believe there is an issue with tags using either "openBlockWith" or "closeBlockWith". If you don't select any text and apply such tag, carret is supposed to select placeholder text (or just move inside the openWith and closeWith tags if there is no placeholder), but indices are wrong when openBlockWith or closeBlockWith are used. This pull request should fix the issue.

Regards,
Remi
