### PR TITLE
Issue in detection of options.root

### DIFF
--- a/markitup/jquery.markitup.js
+++ b/markitup/jquery.markitup.js
@@ -59,7 +59,7 @@
 		// compute markItUp! path
 		if (!options.root) {
 			$('script').each(function(a, tag) {
-				miuScript = $(tag).get(0).src.match(/(.*)jquery\.markitup(\.pack)?\.js$/);
+				miuScript = $(tag).get(0).src.match(/(.*)jquery\.markitup(\.pack)?\.js(.*)$/);
 				if (miuScript !== null) {
 					options.root = miuScript[1];
 				}


### PR DESCRIPTION
In my case, i have .js files with parameters:

´´´ ruby
< script type="text/javascript" src="/jq/markitup/jquery.markitup.js?v=1.x.x" >< /script>
´´´

Your detection doesn't work with that format ;)

Best Regards,
Alexander Bulei
