### PR TITLE
make markItUpRemove function idempotent

### DIFF
--- a/markitup/jquery.markitup.js
+++ b/markitup/jquery.markitup.js
@@ -636,6 +636,9 @@
 			function remove() {
 				$$.unbind(".markItUp").removeClass('markItUpEditor');
 				$$.parent('div').parent('div.markItUp').parent('div').replaceWith($$);
+				var relative_ref = $$.parent('div').parent('div.markItUp').parent('div');
+				if (relative_ref.length)
+				    relative_ref.replaceWith($$);
 				$$.data('markItUp', null);
 			}
 


### PR DESCRIPTION
Hi,

here are small fix that makes markItUp function idempotent. Old version wasn't idempotent since $([]).replaceWith($$) wipes original contents of $$. So when you're doing remove() twice original textarea disappears.
