### PR TITLE
Mark as compatible with jQuery 2.x in bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -11,6 +11,6 @@
     "vendor"
   ],
   "dependencies": {
-    "jquery": "^1.4.2"
+    "jquery": ">=1.4.2 <3.0.0"
   }
 }


### PR DESCRIPTION
Markitup works properly with jQuery 2.x, I just had to update the bower.json file. Cheers!