### PR TITLE
no template usage when using previewParser

### DIFF
--- a/markitup/jquery.markitup.js
+++ b/markitup/jquery.markitup.js
@@ -538,18 +538,19 @@
 
 			function renderPreview() {
 				var phtml;
+				var parsedData = $$.val();
+				if (options.previewParser && typeof options.previewParser === 'function') {
+					parsedData = options.previewParser(parsedData); 
+				}
 				if (options.previewHandler && typeof options.previewHandler === 'function') {
-					options.previewHandler( $$.val() );
-				} else if (options.previewParser && typeof options.previewParser === 'function') {
-					var data = options.previewParser( $$.val() );
-					writeInPreview(localize(data, 1) ); 
+					options.previewHandler(parsedData);
 				} else if (options.previewParserPath !== '') {
 					$.ajax({
 						type: options.previewParserAjaxType,
 						dataType: 'text',
 						global: false,
 						url: options.previewParserPath,
-						data: options.previewParserVar+'='+encodeURIComponent($$.val()),
+						data: options.previewParserVar+'='+encodeURIComponent(parsedData),
 						success: function(data) {
 							writeInPreview( localize(data, 1) ); 
 						}
@@ -561,7 +562,7 @@
 							dataType: 'text',
 							global: false,
 							success: function(data) {
-								writeInPreview( localize(data, 1).replace(/<!-- content -->/g, $$.val()) );
+								writeInPreview( localize(data, 1).replace(/<!-- content -->/g, parsedData) );
 							}
 						});
 					}


### PR DESCRIPTION
I wanted to use previewParser results in an output based on the template defined in previewTeamplatePath. So I turned previewParser into a "preprocessor". The rest of the rendering follows afterwards.

This change should also allow the use of previewParser in conjunction with a previewHandler or previewParserPath.