### PR TITLE
[Bower] The "main" field cannot contain globs

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "markitup",
-  "version": "1.1.14",
-  "main": [ "markitup/jquery.markitup.js", "sets/*", "skins/*", "images/*" ],
+  "version": "1.1.15",
+  "main": [ "markitup/jquery.markitup.js" ],
   "ignore": [
     "markitup/templates/*",
     "node_modules",


### PR DESCRIPTION
I have the following while installing Markitup with Bower:

Command: `bower install markitup#master`

```
bower markitup#master       not-cached https://github.com/markitup/1.x.git#master
bower markitup#master          resolve https://github.com/markitup/1.x.git#master
bower markitup#master         download https://github.com/markitup/1.x/archive/master.tar.gz
bower markitup#master          extract archive.tar.gz
bower markitup#master     invalid-meta for:path/to/bower.json
bower markitup#master     invalid-meta The "main" field cannot contain globs (example: "*.js")
bower markitup#master     invalid-meta The "main" field cannot contain globs (example: "*.js")
bower markitup#master     invalid-meta The "main" field cannot contain globs (example: "*.js")
bower markitup#master         resolved https://github.com/markitup/1.x.git#e147ca3555
bower jquery#>=1.4.2            cached https://github.com/jquery/jquery-dist.git#3.3.1
bower jquery#>=1.4.2          validate 3.3.1 against https://github.com/jquery/jquery-dist.git#>=1.4.2
bower markitup#master          install markitup#e147ca3555
bower jquery#>=1.4.2           install jquery#3.3.1

```